### PR TITLE
[FIX] use dash if the description would be entirely empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
- Byte-compiled / optimized / DLL files
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 /.venv

--- a/sale_order_line_no_description_update/README.rst
+++ b/sale_order_line_no_description_update/README.rst
@@ -5,10 +5,13 @@
 =======================================
 Sale: never auto-update SOL description
 =======================================
-This module prevents Odoo from automatically regenerating the sales order line
-description (field ``name``) when the product is set or changed. The existing
-value in ``name`` is kept as-is, allowing manual or custom descriptions to
-remain untouched.
+* This module prevents Odoo from automatically regenerating the sales order line
+  description (field ``name``) when the product is set or changed. The existing
+  value in ``name`` is kept as-is, allowing manual or custom descriptions to
+  remain untouched.
+* However, if the description field would be empty, a "-" character will be used,
+  to avoid issues with other modules' functionalities that expect the description
+  field to never be empty.
 
 Installation
 ============
@@ -38,12 +41,13 @@ Credits
 Contributors
 ------------
 * Valtteri Lattu <valtteri.lattu@futural.fi>
+* Timo Talvitie <timo.talvitie@futural.fi>
 
 Maintainer
 ----------
 
-.. image:: http://tawasta.fi/templates/tawastrap/images/logo.png
-   :alt: Oy Tawasta OS Technologies Ltd.
-   :target: http://tawasta.fi/
+.. image:: https://futural.fi/templates/tawastrap/images/logo.png
+   :alt: Futural Oy
+   :target: https://futural.fi/
 
-This module is maintained by Oy Tawasta OS Technologies Ltd.
+This module is maintained by Futural Oy

--- a/sale_order_line_no_description_update/__manifest__.py
+++ b/sale_order_line_no_description_update/__manifest__.py
@@ -1,7 +1,7 @@
 ##############################################################################
 #
-#    Author: Oy Tawasta OS Technologies Ltd.
-#    Copyright 2020- Oy Tawasta OS Technologies Ltd. (https://tawasta.fi)
+#    Author: Futural Oy
+#    Copyright 2026- Futural Oy (https://futural.fi)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as

--- a/sale_order_line_no_description_update/models/sale_order_line.py
+++ b/sale_order_line_no_description_update/models/sale_order_line.py
@@ -11,7 +11,11 @@ class SaleOrderLine(models.Model):
         Keep whatever is already stored in `name`.
         """
         # IMPORTANT: do not call super()
-        for _ in self:
-            # Intentionally do nothing to prevent Odoo from
-            # overwriting the existing description.
-            pass
+        for line in self:
+            # If empty, set a dash to avoid issues with the name field
+            # being entirely empty.
+            #
+            # If not empty, intentionally do nothing to prevent Odoo from
+            # overwriting the existing (manually written) description.
+            if not line.name:
+                line.name = "-"


### PR DESCRIPTION
- fixes potential crash on separate functionalities that assume the SO line description to always contain something